### PR TITLE
fix: github action permissions for sarif upload

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 env:
   # This is where you will need to introduce the Snyk API token created with your Snyk account


### PR DESCRIPTION
The GitHub Action that does security scanning on the code currently fails when it attempts to upload the results to GitHub. This change adds the necessary permission assertion to allow it to succeed.