### PR TITLE
fix: add write permission for statuses

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  statuses: write
 
 env:
   # This is where you will need to introduce the Snyk API token created with your Snyk account


### PR DESCRIPTION
Speculative attempt to fix the GitHub action that's failing, based on the fact that we're getting a 403 when trying to `PUT` to a `/status` URL.