### PR TITLE
fix: add read permission for actions

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -5,6 +5,7 @@ on:
     branches: ['main']
 
 permissions:
+  actions: read
   contents: read
   security-events: write
   statuses: write


### PR DESCRIPTION
One more try at setting the right permissions for the `github/codeql-action/upload-sarif@v2` action before I give up.