### PR TITLE
fix(actions): Synk analysis upload

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,8 @@
         "esbenp.prettier-vscode",
         "stylelint.vscode-stylelint",
         "bradlc.vscode-tailwindcss",
-        "snyk-security.snyk-vulnerability-scanner"
+        "snyk-security.snyk-vulnerability-scanner",
+        "github.vscode-github-actions"
       ],
       "settings": {
         "jest.autoRun": {

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches: ['main']
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
-  statuses: write
-
 env:
   # This is where you will need to introduce the Snyk API token created with your Snyk account
   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -17,7 +11,10 @@ env:
 jobs:
   snyk:
     permissions:
-      contents: read # for actions/checkout to fetch code
+      actions: read
+      contents: read
+      security-events: write
+      statuses: write
     runs-on: ubuntu-latest
     environment: Continuous Deployment
     steps:


### PR DESCRIPTION
Moves the permissions block on the job to inside the job, this should hopefully stop them being overridden as they have been.